### PR TITLE
Remove dio timeout

### DIFF
--- a/lib/src/ardrive_http.dart
+++ b/lib/src/ardrive_http.dart
@@ -91,9 +91,6 @@ class ArDriveHTTP {
           .get(
             url,
             options: Options(responseType: responseType),
-          )
-          .timeout(
-            const Duration(seconds: 8), // 8s timeout
           );
 
       return ArDriveHTTPResponse(
@@ -220,9 +217,6 @@ class ArDriveHTTP {
               contentType: contentType.toString(),
               responseType: responseType,
             ),
-          )
-          .timeout(
-            const Duration(seconds: 8), // 8s timeout
           );
 
       return ArDriveHTTPResponse(


### PR DESCRIPTION
PE-2991 equivalent for nativemobile.

<img width="869" alt="Screenshot 2023-02-16 at 8 02 56 AM" src="https://user-images.githubusercontent.com/7699058/219224004-b393e861-1685-427c-a7d7-57822b31c1e2.png">

Timeout is still happening on dio `get` implementation (when returning a slow response).