### PR TITLE
Support for download via byte stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ ArDriveHTTP is a package to perform network calls for ArDrive Web. It uses Isola
 - get()
 - getJson()
 - getAsBytes()
+- getAsByteStream()
+  - Note: does not use Isolates or WebWorkers
 
 ## Getting started
 

--- a/lib/src/ardrive_http.dart
+++ b/lib/src/ardrive_http.dart
@@ -6,10 +6,12 @@ import 'dart:math';
 import 'package:ardrive_http/src/responses.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_smart_retry/dio_smart_retry.dart';
-import 'package:fetch_client/fetch_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:isolated_worker/js_isolated_worker.dart';
+
+import 'io/fetch_client_stub.dart'
+  if (dart.library.html) 'package:fetch_client/fetch_client.dart' as fetch;
 
 const List<String> jsScriptsToImport = <String>['ardrive-http.js'];
 
@@ -90,7 +92,9 @@ class ArDriveHTTP {
   }
 
   Future<ArDriveHTTPResponse> getAsByteStream(String url) async {
-    final client = kIsWeb? FetchClient() : http.Client();
+    final client = kIsWeb 
+      ? fetch.FetchClient(mode: fetch.RequestMode.cors)
+      : http.Client();
     final response = await client.send(
       http.Request(
         'GET', 

--- a/lib/src/ardrive_http.dart
+++ b/lib/src/ardrive_http.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:ardrive_http/src/responses.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_smart_retry/dio_smart_retry.dart';
+import 'package:fetch_client/fetch_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:isolated_worker/js_isolated_worker.dart';
@@ -89,8 +90,13 @@ class ArDriveHTTP {
   }
 
   Future<ArDriveHTTPResponse> getAsByteStream(String url) async {
-    final client = http.Client();
-    final response = await client.send(http.Request('GET', Uri.parse(url)));
+    final client = kIsWeb? FetchClient() : http.Client();
+    final response = await client.send(
+      http.Request(
+        'GET', 
+        Uri.parse(url),
+      ),
+    );
     final byteStream = response.stream.map((event) => Uint8List.fromList(event));
     return ArDriveHTTPResponse(
       data: byteStream,

--- a/lib/src/ardrive_http.dart
+++ b/lib/src/ardrive_http.dart
@@ -7,6 +7,7 @@ import 'package:ardrive_http/src/responses.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import 'package:isolated_worker/js_isolated_worker.dart';
 
 const List<String> jsScriptsToImport = <String>['ardrive-http.js'];
@@ -85,6 +86,18 @@ class ArDriveHTTP {
 
   Future<ArDriveHTTPResponse> getAsBytes(String url) async {
     return get(url: url, responseType: ResponseType.bytes);
+  }
+
+  Future<ArDriveHTTPResponse> getAsByteStream(String url) async {
+    final client = http.Client();
+    final response = await client.send(http.Request('GET', Uri.parse(url)));
+    final byteStream = response.stream.map((event) => Uint8List.fromList(event));
+    return ArDriveHTTPResponse(
+      data: byteStream,
+      statusCode: response.statusCode,
+      statusMessage: response.reasonPhrase,
+      retryAttempts: retryAttempts,
+    );
   }
 
   Future<ArDriveHTTPResponse> _getIO(Map params) async {

--- a/lib/src/io/fetch_client_stub.dart
+++ b/lib/src/io/fetch_client_stub.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart';
+
+enum RequestMode {
+  sameOrigin('same-origin'),
+  noCors('no-cors'),
+  cors('cors'),
+  navigate('navigate'),
+  webSocket('websocket');
+
+  const RequestMode(this.mode);
+
+  factory RequestMode.from(String mode) =>
+    values.firstWhere((element) => element.mode == mode);
+
+  final String mode;
+
+  @override
+  String toString() => mode;
+}
+
+
+class FetchClient implements BaseClient {
+  FetchClient({
+    RequestMode? mode,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void close() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response> delete(Uri url, {Map<String, String>? headers, Object? body, Encoding? encoding}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response> get(Uri url, {Map<String, String>? headers}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response> head(Uri url, {Map<String, String>? headers}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response> patch(Uri url, {Map<String, String>? headers, Object? body, Encoding? encoding}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response> post(Uri url, {Map<String, String>? headers, Object? body, Encoding? encoding}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response> put(Uri url, {Map<String, String>? headers, Object? body, Encoding? encoding}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> read(Uri url, {Map<String, String>? headers}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers}) {
+    throw UnimplementedError();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: '>=2.18.5 <3.0.0'
-  flutter: 3.3.9
+  flutter: 3.7.0
 
 script_runner:
   shell:
@@ -24,7 +24,7 @@ dependencies:
   dio: ^5.0.0
   dio_smart_retry: ^5.0.0
   equatable: ^2.0.5
-  fetch_client: ^1.0.0-dev.2
+  fetch_client: ^1.0.0
   flutter:
     sdk: flutter
   http: ^0.13.5
@@ -37,3 +37,11 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.1
   async: ^2.9.0
+
+# `fetch_api` from `fetch_client` specifies `js: ^0.6.7`, however
+# this is incompatible with `js: ^0.6.5` from Flutter SDK `3.7.0`
+# Issue: https://github.com/Zekfad/fetch_api/pull/2
+
+# Workaround: solves the dependency conflict by using the newer version.
+dependency_overrides:
+  js: ^0.6.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,11 +37,3 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.1
   async: ^2.9.0
-
-# `fetch_api` from `fetch_client` specifies `js: ^0.6.7`, however
-# this is incompatible with `js: ^0.6.5` from Flutter SDK `3.7.0`
-# Issue: https://github.com/Zekfad/fetch_api/pull/2
-
-# Workaround: solves the dependency conflict by using the newer version.
-dependency_overrides:
-  js: ^0.6.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
+  http: ^0.13.5
   isolated_worker: ^0.1.1
   shelf: ^1.4.0
   shelf_router: ^1.1.3
@@ -34,3 +35,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
+  async: ^2.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   dio: ^5.0.0
   dio_smart_retry: ^5.0.0
   equatable: ^2.0.5
+  fetch_client: ^1.0.0-dev.2
   flutter:
     sdk: flutter
   http: ^0.13.5

--- a/test/ardrive_http_test.dart
+++ b/test/ardrive_http_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:ardrive_http/ardrive_http.dart';
+import 'package:async/async.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -60,6 +61,16 @@ void main() {
 
         expect(getAsBytesResponse.data, Uint8List.fromList([111, 107]));
         expect(getAsBytesResponse.retryAttempts, 0);
+      });
+
+      test('returns byte stream response', () async {
+        const String url = '$baseUrl/ok';
+
+        final getResponse = await http.getAsByteStream(url);
+        final byteStream = getResponse.data as Stream<Uint8List>;
+
+        expect(collectBytes(byteStream), completion(Uint8List.fromList([111, 107])));
+        expect(getResponse.retryAttempts, 0);
       });
 
       test('fail without retry', () async {


### PR DESCRIPTION
A few problems I encountered that lead me to this particular solution:
- When downloading in chunks via HTTP `Range` header, the `arweave.net` gateway will eventually rate limit your requests, even with large chunks. Gateway then does exponential backoff which can seriously impact download time.
- Naively wrapping a stream result in WebWorkers and Isolates causes errors
- `dio` streams are a lie - it downloads a buffer and wraps it in `Stream.value`
- `package:http` on web still use XHR requests, also without real stream support: https://github.com/dart-lang/http/issues/595

So to get around all of these issues:
- Use a single HTTP request to prevent rate limiting
- Use `fetch` on web (using `fetch_client` library instead of `ardrive-http.ts` to handle the more complex js/dart interop)
- Use the low level `HttpClient` on mobile which just works

I've confirmed that the memory usage on web is stable. Not sure how to confirm on mobile

Caveats of this method:
- Streamed responses do not run in a WebWorker or Dart Isolate
- Lack of flow control in `fetch`. Seems that this cannot be fixed: https://github.com/Zekfad/fetch_client/issues/3
  - This means the possibility of unbounded memory usage, but only in circumstances where the download speed exceeds the save/decrypt speed. In practice this should be very rare (decrypt speed is 100s of MiB/s on my M1 air, disk speed even faster). Could crop up when saving to a slow flash drive or SD card? It may pay to warn users about this.