### PR TITLE
v1.3.1

### DIFF
--- a/lib/src/ardrive_http.dart
+++ b/lib/src/ardrive_http.dart
@@ -436,6 +436,10 @@ class ArDriveHTTP {
         List.generate(retries, (index) => retryDelay(index));
 
     FutureOr<bool> setRetryAttempt(DioError error, int attempt) async {
+      if (error.response?.statusCode == 408) {
+        return false;
+      }
+
       bool shouldRetry =
           await RetryInterceptor.defaultRetryEvaluator(error, attempt);
 

--- a/test/webserver.dart
+++ b/test/webserver.dart
@@ -6,7 +6,6 @@ import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_router/shelf_router.dart';
 
 List<int> retryStatusCodes = [
-  408,
   429,
   440,
   460,


### PR DESCRIPTION
- Remove retry for status code `408` on post and get using `IO`